### PR TITLE
Handle multiple occurrences and escaped underscores/asterisks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,58 +2,84 @@ const ASTERISK_ITALIC = '*';
 const UNDERSCORE_ITALIC = '_';
 const ASTERISK_BOLD = '**';
 const UNDERSCORE_BOLD = '__';
+const ESCAPED_UNDERSCORE = '\\_';
+const ESCAPED_ASTERISK = '\\*'
 
+const ESCAPED_ASTERISK_REGEXP = /\\\*/g;
 const ASTERISK_PLACEHOLDER_REGEXP = /ASTERISKPLACEHOLDER/gm;
+
+const ESCAPED_UNDERSCORE_REGEXP = /\\_/g;
 const UNDERSCORE_PLACEHOLDER_REGEXP = /UNDERSCOREPLACEHOLDER/gm;
 
 const UNDERSCORE_BOLD_PLACEHOLDER_REGEXP = /UNDERSCOREBOLDPLACEHOLDER/gm;
-const UNDERSCORE_BOLD_REGEXP = /__(.*)__/gim;
+const UNDERSCORE_BOLD_REGEXP = /(__)(.*?)(__)/g;
 
 const ASTERISK_BOLD_PLACEHOLDER_REGEXP = /ASTERISKBOLDPLACEHOLDER/gm;
-const ASTERISK_BOLD_REGEXP = /\*\*(.*)\*\*/gim;
+const ASTERISK_BOLD_REGEXP = /(\*\*)(.*?)(\*\*)/g;
 
 const UNDERSCORE_ITALIC_PLACEHOLDER_REGEXP = /UNDERSCOREITALICPLACEHOLDER/gm;
-const UNDERSCORE_ITALIC_REGEXP = /_(.*)_/gim;
+const UNDERSCORE_ITALIC_REGEXP = /(_)(.*?)(_)/g;
 
 const ASTERISK_ITALIC_PLACEHOLDER_REGEXP = /ASTERISKITALICPLACEHOLDER/gm;
-const ASTERISK_ITALIC_REGEXP = /\*(.*)\*/gim;
+const ASTERISK_ITALIC_REGEXP = /(\*)(.*?)(\*)/g;
 
 const HYPERLINK = /^\[([^[]+)\]\(([^)]+)\)/;
 
 const replaceFormatMarkersWithPlaceholders = text =>
   text
+    .replace(ESCAPED_UNDERSCORE_REGEXP, UNDERSCORE_PLACEHOLDER_REGEXP.source)
+    .replace(ESCAPED_ASTERISK_REGEXP, ASTERISK_PLACEHOLDER_REGEXP.source)
     .replace(
       UNDERSCORE_BOLD_REGEXP,
-      `${UNDERSCORE_BOLD_PLACEHOLDER_REGEXP.source}$1${UNDERSCORE_BOLD_PLACEHOLDER_REGEXP.source}`
+      `${UNDERSCORE_BOLD_PLACEHOLDER_REGEXP.source}$2${UNDERSCORE_BOLD_PLACEHOLDER_REGEXP.source}`
     )
     .replace(
       ASTERISK_BOLD_REGEXP,
-      `${ASTERISK_BOLD_PLACEHOLDER_REGEXP.source}$1${ASTERISK_BOLD_PLACEHOLDER_REGEXP.source}`
+      `${ASTERISK_BOLD_PLACEHOLDER_REGEXP.source}$2${ASTERISK_BOLD_PLACEHOLDER_REGEXP.source}`
     )
     .replace(
       UNDERSCORE_ITALIC_REGEXP,
-      `${UNDERSCORE_ITALIC_PLACEHOLDER_REGEXP.source}$1${UNDERSCORE_ITALIC_PLACEHOLDER_REGEXP.source}`
+      `${UNDERSCORE_ITALIC_PLACEHOLDER_REGEXP.source}$2${UNDERSCORE_ITALIC_PLACEHOLDER_REGEXP.source}`
     )
     .replace(
       ASTERISK_ITALIC_REGEXP,
-      `${ASTERISK_ITALIC_PLACEHOLDER_REGEXP.source}$1${ASTERISK_ITALIC_PLACEHOLDER_REGEXP.source}`
+      `${ASTERISK_ITALIC_PLACEHOLDER_REGEXP.source}$2${ASTERISK_ITALIC_PLACEHOLDER_REGEXP.source}`
     );
 
 const replaceFormatPlaceholdersWithMarkers = text =>
   text
-    .replace(UNDERSCORE_BOLD_PLACEHOLDER_REGEXP, UNDERSCORE_BOLD)
-    .replace(ASTERISK_BOLD_PLACEHOLDER_REGEXP, ASTERISK_BOLD)
-    .replace(UNDERSCORE_ITALIC_PLACEHOLDER_REGEXP, UNDERSCORE_ITALIC)
-    .replace(ASTERISK_ITALIC_PLACEHOLDER_REGEXP, ASTERISK_ITALIC);
+  .replace(UNDERSCORE_PLACEHOLDER_REGEXP, ESCAPED_UNDERSCORE)
+  .replace(ASTERISK_PLACEHOLDER_REGEXP, ESCAPED_ASTERISK)
+  .replace(UNDERSCORE_BOLD_PLACEHOLDER_REGEXP, UNDERSCORE_BOLD)
+  .replace(ASTERISK_BOLD_PLACEHOLDER_REGEXP, ASTERISK_BOLD)
+  .replace(UNDERSCORE_ITALIC_PLACEHOLDER_REGEXP, UNDERSCORE_ITALIC)
+  .replace(ASTERISK_ITALIC_PLACEHOLDER_REGEXP, ASTERISK_ITALIC);
 
 const formatMarkers = [
   ASTERISK_BOLD_PLACEHOLDER_REGEXP.source,
   UNDERSCORE_BOLD_PLACEHOLDER_REGEXP.source,
   ASTERISK_ITALIC_PLACEHOLDER_REGEXP.source,
-  UNDERSCORE_ITALIC_PLACEHOLDER_REGEXP.source
+  UNDERSCORE_ITALIC_PLACEHOLDER_REGEXP.source,
 ];
 
-const formatMarkerAhead = (text, formatStack) => {
+const formatPlaceholdersMap = {
+  [UNDERSCORE_PLACEHOLDER_REGEXP.source]: ESCAPED_UNDERSCORE.length,
+  [ASTERISK_PLACEHOLDER_REGEXP.source]: ESCAPED_ASTERISK.length,
+}
+
+const findFormatPlaceholderAhead = (text) => {
+  const formatPlaceholders = Object.keys(formatPlaceholdersMap);
+
+  for (let i = 0, l = formatPlaceholders.length; i < l; i++) {
+    if (text.startsWith(formatPlaceholders[i])) {
+      return formatPlaceholders[i];
+    }
+  }
+
+  return null;
+}
+
+const findFormatMarkerAhead = (text, formatStack) => {
   for (let i = 0, l = formatMarkers.length; i < l; i++) {
     if (text.startsWith(formatMarkers[i])) {
       if (formatStack[formatStack.length - 1] === formatMarkers[i]) {
@@ -64,6 +90,7 @@ const formatMarkerAhead = (text, formatStack) => {
       return formatMarkers[i];
     }
   }
+
   return null;
 };
 
@@ -77,11 +104,19 @@ const truncate = (text, limit, ellipsis) => {
     let index = 0;
 
     while (count < limit && index < text.length) {
-      const formatMarker = formatMarkerAhead(text.substring(index), formatStack);
+      const formatMarker = findFormatMarkerAhead(text.substring(index), formatStack);
       if (formatMarker) {
         outputText += formatMarker;
         index += formatMarker.length;
         skipCountIncrement = true;
+      }
+
+      const formatPlaceholder = findFormatPlaceholderAhead(text.substring(index));
+      if (formatPlaceholder) {
+        outputText += formatPlaceholder;
+        index += formatPlaceholder.length;
+        skipCountIncrement = true;
+        count += formatPlaceholdersMap[formatPlaceholder];
       }
 
       const hyperlinkAheadRegexp = new RegExp(HYPERLINK);
@@ -107,7 +142,7 @@ const truncate = (text, limit, ellipsis) => {
       skipCountIncrement = false;
     }
 
-    outputText = outputText.trimEnd()
+    outputText = outputText.trimEnd();
 
     while (formatStack.length > 0) {
       outputText += formatStack.pop();
@@ -126,9 +161,9 @@ const truncate = (text, limit, ellipsis) => {
 };
 
 module.exports = function (text = '', options = {}) {
-  const { limit, ellipsis } = options || {}
+  const { limit, ellipsis } = options || {};
 
- if (isNaN(parseInt(limit, 10)) || text.length <= limit) {
+  if (isNaN(parseInt(limit, 10)) || text.length <= limit) {
     return text;
   }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -35,14 +35,14 @@ describe('truncateMarkdown test suite', () => {
       { limit: 20, ellipsis: true },
     ],
     [
-      '_underscores_wrapped_in_italics_ are truncated correctly',
-      '_underscores_wrapped_in_it_...',
-      { limit: 25, ellipsis: true },
+      'underscores must _be\\_wrapped\\_in\\_italics_ to be truncated correctly',
+      'underscores must _be\\_wrapped\\_in\\_ita_...',
+      { limit: 34, ellipsis: true },
     ],
     [
-      '**asterisks*wrapped*in*bold** are truncated correctly',
-      '**asterisks*wrapped*in*b**...',
-      { limit: 20, ellipsis: true },
+      'asterisks must **be\\*wrapped\\*in\\*bold** to be truncated correctly',
+      'asterisks must **be\\*wrapped\\*in\\*b**...',
+      { limit: 30, ellipsis: true },
     ],
     [
       'truncation trims **trailing     spaces**',
@@ -69,6 +69,11 @@ describe('truncateMarkdown test suite', () => {
       '_[**italics wrapping links with bold text**](https://google.com)_ are also truncated',
       '_[**italics wrapping lin**](https://google.com)_',
       { limit: 20 },
+    ],
+    [
+      'Enter some *markdown text* **here**, change the **character _limit_**, and check that the text is __properly__ truncated',
+      'Enter some *markdown text* **here**, change the **character _lim_**',
+      { limit: 55 }
     ],
   ])('%s is truncated correctly', (input, expected, options) => {
     const output = truncateMarkdown(input, options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,7 +1826,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -2925,7 +2925,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4099,11 +4099,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4112,32 +4107,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -4173,11 +4146,6 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Fix issue with multiple occurrences of bolds and italics in the same sentence, which didn't work before.

Also, as opposed to how Markdown usually works, asterisks and underscores nested within text are treated as emphasis markers too so, in order to differentiate them from emphasis markers, they need to be escaped (written with backslashes).

I.e.
`these_underscores_are_all_treated_as_italics`
vs
`these\\_escaped\\_underscores\\_are\\_regular\\_underscores`

This PR supersedes [this other one](https://github.com/pchiwan/markdown-truncate/pull/3) which had been open for more than a year 😅😓 
